### PR TITLE
Fix stale status when presence updates share the same timestamp

### DIFF
--- a/src/js/presence-store.js
+++ b/src/js/presence-store.js
@@ -48,7 +48,7 @@ export function buildCurrentPresence(events, ttlMinutes) {
     }
 
     const existing = latestByUser.get(event.user);
-    if (!existing || Date.parse(existing.createdAt) < createdAtMillis) {
+    if (!existing || Date.parse(existing.createdAt) <= createdAtMillis) {
       latestByUser.set(event.user, event);
     }
   }


### PR DESCRIPTION
### Motivation
- Behebt ein Problem, bei dem ein kurz nacheinander gesetzter Status wegen identischer `createdAt`-Timestamps nicht das vorherige Eintrag überschreibt und somit in der Liste veraltet angezeigt wird.

### Description
- Ändert die Vergleichslogik in `buildCurrentPresence` von `<` zu `<=` so dass bei identischem Timestamp der später verarbeitete Eintrag den vorhandenen Eintrag ersetzt (`src/js/presence-store.js`, Vergleich auf `Date.parse(existing.createdAt) <= createdAtMillis`).

### Testing
- Es gibt keine automatisierten Tests im Repository; keine automatischen Tests wurden ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39c9ada78832aaf10984826772ffd)