### PR TITLE
Preserve refresh countdown when submitting presence update

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -78,7 +78,7 @@ async function submitPresence(event) {
     localStorage.setItem(storageKeys.room, presenceEvent.room);
 
     await client.createComment(issue.number, encodeEvent(presenceEvent));
-    await refreshPresence();
+    await refreshPresence({ preserveCountdown: true });
   } catch (error) {
     showError(error.message);
   }
@@ -94,7 +94,9 @@ async function refreshPresence(options = {}) {
         if (!issue) {
             renderPresence([]);
             setConnectionState('Verbunden', 'ok');
-            resetAutoRefreshCountdown();
+            if (!options.preserveCountdown) {
+                resetAutoRefreshCountdown();
+            }
             return;
         }
 
@@ -104,7 +106,9 @@ async function refreshPresence(options = {}) {
 
         renderPresence(currentPresence);
         setConnectionState('Verbunden', 'ok');
-        resetAutoRefreshCountdown();
+        if (!options.preserveCountdown) {
+            resetAutoRefreshCountdown();
+        }
     } catch (error) {
         setConnectionState('Fehler', 'error');
         if (!options.silent) {


### PR DESCRIPTION
### Motivation
- Beim Absenden einer Anwesenheitsaktualisierung soll der laufende Auto-Refresh-Countdown nicht neu gestartet werden, damit die Anzeige weiter herunterzählt und der Benutzer nicht durch einen Reset verwirrt wird.

### Description
- In `src/js/app.js` wird `refreshPresence` beim Submit jetzt mit `{ preserveCountdown: true }` aufgerufen.
- `refreshPresence(options)` überspringt das Aufrufen von `resetAutoRefreshCountdown()` wenn `options.preserveCountdown` gesetzt ist.
- Die Änderung betrifft ausschließlich die Logik rund um das Rücksetzen des Auto-Refresh-Timers in `src/js/app.js`.

### Testing
- `node --check src/js/app.js` wurde ausgeführt und meldete keine Fehler.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a5c4b1b0832a831b225b47265425)